### PR TITLE
Update to latest browsertime package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "args": "^2.2.4",
-    "browsertime": "1.0.0-beta.23",
+    "browsertime": "^2.5.0",
     "chalk": "^1.1.3",
     "cli-table": "^0.3.1"
   },


### PR DESCRIPTION
With this change, the script will run with latest Chrome (67)
because the latest chromedriver will be used.