### PR TITLE
Run loading comparison in headless mode

### DIFF
--- a/bin/loading-comparison.js
+++ b/bin/loading-comparison.js
@@ -45,6 +45,7 @@ const options = [
   {
     browser: cliArguments.browser,
     'connectivity.profile': cliArguments.connectivity,
+    headless: true,
     iterations: cliArguments.iterations,
     output: path.parse(resultFile).name,
     resultDir: resultDirectory,


### PR DESCRIPTION
Maybe this should be configurable via CLI args.

Viewing the progress could be a desired feature.